### PR TITLE
Load index.css by blocking

### DIFF
--- a/templates/partials/head.ejs
+++ b/templates/partials/head.ejs
@@ -6,11 +6,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link rel="preload" href="https://fonts.googleapis.com/css?family=Mali:400,400i,700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <link rel="preload" href="<%= `${path.root}assets/highlight.css` %>" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="<%= `${path.root}assets/index.css` %>" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <link rel="stylesheet" href="<%= `${path.root}assets/index.css` %>">
   <noscript>
     <link href="https://fonts.googleapis.com/css?family=Mali:400,400i,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="<%= `${path.root}assets/highlight.css` %>">
-    <link rel="stylesheet" href="<%= `${path.root}assets/index.css` %>">
   </noscript>
   <title><%= site.name %> - <%= page.title %></title>
 </head>


### PR DESCRIPTION
Revert to load index.css synchronously (blocking), because it looks too ugly while the css is being loaded. The lighthouse performance score is still 100 anyway